### PR TITLE
Upgrade deprecated runtime python3.7

### DIFF
--- a/iot-data-ingestion.json
+++ b/iot-data-ingestion.json
@@ -1083,7 +1083,7 @@
 						} 
 				},
 				"Role"    : { "Fn::GetAtt": [ "IAMRoleKPIsGenerator", "Arn"]},
-				"Runtime" : "python3.7",
+				"Runtime" : "python3.10",
 				"Timeout" : 3
 			}
 		} ,


### PR DESCRIPTION
CloudFormation templates in cloudformation-blog-iot-data-ingestion have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (python3.7). The affected templates have been updated to a supported runtime (python3.10).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.